### PR TITLE
Replace 'Login with...' page with auto-redirect script

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
   helper_method :whitelist_mode?
   helper_method :body_class_string
   helper_method :skip_csrf_meta_tags?
+  helper_method :sso_redirect
 
   rescue_from ActionController::ParameterMissing, Paperclip::AdapterRegistry::NoHandlerError, with: :bad_request
   rescue_from Mastodon::NotPermittedError, with: :forbidden
@@ -133,6 +134,10 @@ class ApplicationController < ActionController::Base
 
   def omniauth_only?
     ENV['OMNIAUTH_ONLY'] == 'true'
+  end
+
+  def sso_redirect
+    "/auth/auth/#{Devise.omniauth_providers[0]}" if ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1
   end
 
   def sso_account_settings

--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -1,8 +1,9 @@
 - content_for :page_title do
   = t('auth.login')
 
-- content_for :header_tags do
-  = render partial: 'shared/og'
+- unless sso_redirect
+  - content_for :header_tags do
+    = render partial: 'shared/og'
 
 - unless omniauth_only?
   = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
@@ -21,10 +22,32 @@
 
 - if devise_mapping.omniauthable? && resource_class.omniauth_providers.any?
   .simple_form.alternative-login
-    %h4= omniauth_only? ? t('auth.log_in_with') : t('auth.or_log_in_with')
+    - if sso_redirect
+      %h4= 'Redirecting...'
+    -else
+      %h4= omniauth_only? ? t('auth.log_in_with') : t('auth.or_log_in_with')
 
-    .actions
-      - resource_class.omniauth_providers.each do |provider|
-        = provider_sign_in_link(provider)
+      .actions
+        - resource_class.omniauth_providers.each do |provider|
+          = provider_sign_in_link(provider)
 
-.form-footer= render 'auth/shared/links'
+- if sso_redirect
+  :javascript
+    (function() {
+      let form = document.createElement('form');
+      form.action = '#{ sso_redirect }';
+      form.method = 'post';
+      if (localStorage.getItem("mozsoc.auth_intent") == 'signup') {
+        let input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'intent';
+        input.value = 'signup';
+        form.append(input);
+      }
+      localStorage.removeItem('mozsoc.auth_intent');
+      document.body.append(form);
+      form.submit();
+    })();
+
+- unless sso_redirect
+  .form-footer= render 'auth/shared/links'


### PR DESCRIPTION
There is also `localStorage` logic in here to support the "signup intent" feature (two separate buttons). That will be a separate PR on Elk though.

I used `localStorage` because I can't figure out how to prevent Mastodon from stripping all the URL params when redirecting to `/auth/sign_in`.

First part of https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-104