### PR TITLE
patch: change script-src CSP for auth/sign_in

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -16,6 +16,7 @@ class Auth::SessionsController < Devise::SessionsController
 
   content_security_policy only: :new do |p|
     p.form_action(false)
+    p.script_src  :self, :unsafe_inline, "'wasm-unsafe-eval'"
   end
 
   def check_suspicious!


### PR DESCRIPTION
This patches the original Login Interstitial auto-redirect, which didn't work on stage due to a CSP issue