### PR TITLE
fix(session_id): update expiration

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,7 @@ Warden::Manager.after_set_user except: :fetch do |user, warden|
 
   warden.cookies.signed['_session_id'] = {
     value: session_id,
-    expires: 1.year.from_now,
+    expires: 5.minutes.from_now,
     httponly: true,
     same_site: :lax,
   }
@@ -20,7 +20,7 @@ Warden::Manager.after_fetch do |user, warden|
 
     warden.cookies.signed['_session_id'] = {
       value: session_id,
-      expires: 1.year.from_now,
+      expires: 5.minutes.from_now,
       httponly: true,
       same_site: :lax,
     }


### PR DESCRIPTION
Working on this ticket: https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-467

Tbh, I am not sure if this is the way we want to go about this but I figured this was a great way to start the conversation.

Here's some of what I learned while investigating this and some thinking about why I did this here rather than in elk.

1. There are two cookies getting set by mastodon: `_mastodon_session` and `_session_id`.
    - Upon investigation, `_session_id` is the cookie that is causing the login/account switching issue
       - It has an expiration date of `1.year.from_now` but it is also supposed to be getting deleted upon logout, so there may be something more we need to do here than just simply updating the expiry date
    - The `_mastodon_session` cookie does not have an expiration set, so it expires after every session and during my testing this seemed to be working correctly and was not helping to cause the login issue
2. There are no references to cookies anywhere in the elk codebase. I see they are doing some cleanup of user local storage, but nothing specific to cookies.
3. Given 1 & 2, it felt more correct to me to be updating the expiry date of the `_session_id` in the place where it gets set rather than trying to update the expiry date via javascript on the elk side. Also this cookie doesn't get set when only running the elk client locally, so it's a little more of a challenge to test.