### PR TITLE
fix(auth): allow any client to make a signout call

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -7,6 +7,9 @@ class Auth::SessionsController < Devise::SessionsController
   skip_before_action :require_functional!
   skip_before_action :update_user_sign_in
 
+  # Allow any client to call /auth/sign_out via a delete call
+  skip_before_action :verify_authenticity_token, only: [:destroy]
+
   prepend_before_action :check_suspicious!, only: [:create]
 
   include TwoFactorAuthenticationConcern


### PR DESCRIPTION
## Goal

Enable elk (or any client) to sign out of mastodon https://github.com/MozillaSocial/elk/pull/36

## Questions

Is it safe to disable authenticity tokens for logout?