### PR TITLE
Merge 4.2.0 security only

### DIFF
--- a/app/lib/tag_manager.rb
+++ b/app/lib/tag_manager.rb
@@ -7,18 +7,18 @@ class TagManager
   include RoutingHelper
 
   def web_domain?(domain)
-    domain.nil? || domain.delete('/').casecmp(Rails.configuration.x.web_domain).zero?
+    domain.nil? || domain.delete_suffix('/').casecmp(Rails.configuration.x.web_domain).zero?
   end
 
   def local_domain?(domain)
-    domain.nil? || domain.delete('/').casecmp(Rails.configuration.x.local_domain).zero?
+    domain.nil? || domain.delete_suffix('/').casecmp(Rails.configuration.x.local_domain).zero?
   end
 
   def normalize_domain(domain)
     return if domain.nil?
 
     uri = Addressable::URI.new
-    uri.host = domain.delete('/')
+    uri.host = domain.delete_suffix('/')
     uri.normalized_host
   end
 

--- a/app/services/translate_status_service.rb
+++ b/app/services/translate_status_service.rb
@@ -75,7 +75,9 @@ class TranslateStatusService < BaseService
 
       case source
       when :content
-        status_translation.content = unwrap_emoji_shortcodes(translation.text).to_html
+        node = unwrap_emoji_shortcodes(translation.text)
+        Sanitize.node!(node, Sanitize::Config::MASTODON_STRICT)
+        status_translation.content = node.to_html
       when :spoiler_text
         status_translation.spoiler_text = unwrap_emoji_shortcodes(translation.text).content
       when Poll::Option


### PR DESCRIPTION
Fixes 2 security vulnerabilities:
- GHSA-2693-xr3m-jhqr ([advisory](https://github.com/mastodon/mastodon/security/advisories/GHSA-2693-xr3m-jhqr), [commit](https://github.com/mastodon/mastodon/commit/ff32475f5f4a84ebf9619e7eef5bf8b4c075d0e2))
- GHSA-v3xf-c9qf-j667([advisory](https://github.com/mastodon/mastodon/security/advisories/GHSA-v3xf-c9qf-j667), [commit](https://github.com/mastodon/mastodon/commit/eeab3560fc0516070b3fb97e089b15ecab1938c8))

Note that upstream has two versions of the fix for GHSA-2693-xr3m-jhqr – one for [4.1.x](https://github.com/mastodon/mastodon/commit/eeab3560fc0516070b3fb97e089b15ecab1938c8) and one for [4.2.0](https://github.com/mastodon/mastodon/commit/ff32475f5f4a84ebf9619e7eef5bf8b4c075d0e2). I cherry-picked the one for 4.2.0 because our last sync with upstream pulled in many changes from 4.2.0 prematurely, including a newer version of `app/services/translate_status_service.rb` which is where the vulnerability was. The 4.2.0 fix applies to our current version of that file, whereas the fix for 4.1.x is for an older version of that file.