### PR TITLE
chore(copy): [SOCIALPLAT-711] update Language in the Terms of Service, Privacy Policy and other legal documents

### DIFF
--- a/app/javascript/mastodon/features/terms_of_service/index.jsx
+++ b/app/javascript/mastodon/features/terms_of_service/index.jsx
@@ -30,7 +30,7 @@ class TermsOfService extends React.PureComponent {
         <div className='scrollable privacy-policy'>
           <div className='column-title'>
             <h3>Terms of Service</h3>
-            <p>Version 0.1, effective March 31, 2023</p>
+            <p>Version 0.2, effective October 4, 2023</p>
           </div>
 
           <div className='privacy-policy__body prose'>
@@ -46,12 +46,11 @@ class TermsOfService extends React.PureComponent {
               represent that you are authorized to and intend to bind that
               entity.</p>
 
-            <h2 id='fxa-account'>You'll Need A Firefox Account</h2>
+            <h2 id='fxa-account'>You'll Need An Account</h2>
 
-            <p>You need a Firefox account to use Mozilla.social. To create a
-              Firefox account, you will also need to agree to the <a href='https://www.mozilla.org/about/legal/terms/services/'>Mozilla
+            <p>You need an account to use Mozilla.social. To create an account, you will also need to agree to the <a href='https://www.mozilla.org/about/legal/terms/services/'>Mozilla
                 Terms of Service</a> and <a href='https://www.mozilla.org/privacy/firefox/'>Privacy Notice</a> for
-              your Firefox account.</p>
+              your account.</p>
 
             <h2 id='your-privacy'>Your Privacy</h2>
 
@@ -115,8 +114,8 @@ class TermsOfService extends React.PureComponent {
               Mozilla.social account. However, we may retain such data to the
               extent necessary in order to enforce our policies or comply with
               the law, as described in the Mozilla.social Privacy Notice. This
-              will not delete your Firefox account, which you may delete
-              separately on your Firefox account <a href='https://accounts.firefox.com/'>settings page</a>.</p>
+              will not delete your Mozilla account, which you may delete
+              separately on your Mozilla account <a href='https://accounts.firefox.com/'>settings page</a>.</p>
 
             <h2 id='you-are-responsible'>You Are Responsible For the Content You Provide</h2>
 
@@ -175,7 +174,7 @@ class TermsOfService extends React.PureComponent {
               acceptance of such changes. We will post an effective date at the
               top of this page to make it clear when we made our most recent
               update. If the update is significant, we will contact you at the
-              primary email address for your Firefox account to let you know
+              primary email address for your account to let you know
               about the changes.</p>
 
             <p>Termination. These Terms apply until they are modified, or

--- a/app/javascript/mastodon/features/terms_of_service/index.jsx
+++ b/app/javascript/mastodon/features/terms_of_service/index.jsx
@@ -114,8 +114,8 @@ class TermsOfService extends React.PureComponent {
               Mozilla.social account. However, we may retain such data to the
               extent necessary in order to enforce our policies or comply with
               the law, as described in the Mozilla.social Privacy Notice. This
-              will not delete your account, which you may delete
-              separately on your account <a href='https://accounts.firefox.com/'>settings page</a>.</p>
+              will not delete your Mozilla account, which you may delete
+              separately on your Mozilla account <a href='https://accounts.firefox.com/'>settings page</a>.</p>
 
             <h2 id='you-are-responsible'>You Are Responsible For the Content You Provide</h2>
 

--- a/app/javascript/mastodon/features/terms_of_service/index.jsx
+++ b/app/javascript/mastodon/features/terms_of_service/index.jsx
@@ -46,11 +46,11 @@ class TermsOfService extends React.PureComponent {
               represent that you are authorized to and intend to bind that
               entity.</p>
 
-            <h2 id='fxa-account'>You'll Need An Account</h2>
+            <h2 id='mozilla-account'>You'll Need A Mozilla Account</h2>
 
-            <p>You need an account to use Mozilla.social. To create an account, you will also need to agree to the <a href='https://www.mozilla.org/about/legal/terms/services/'>Mozilla
-                Terms of Service</a> and <a href='https://www.mozilla.org/privacy/firefox/'>Privacy Notice</a> for
-              your account.</p>
+            <p>You need a Mozilla account to use Mozilla.social. To create a Mozilla account, you will also need to agree
+              to the <a href='https://www.mozilla.org/about/legal/terms/services/'>Terms of Service</a>
+              and <a href='https://www.mozilla.org/privacy/firefox/'>Privacy Notice</a> for your Mozilla account.</p>
 
             <h2 id='your-privacy'>Your Privacy</h2>
 
@@ -114,8 +114,8 @@ class TermsOfService extends React.PureComponent {
               Mozilla.social account. However, we may retain such data to the
               extent necessary in order to enforce our policies or comply with
               the law, as described in the Mozilla.social Privacy Notice. This
-              will not delete your Mozilla account, which you may delete
-              separately on your Mozilla account <a href='https://accounts.firefox.com/'>settings page</a>.</p>
+              will not delete your account, which you may delete
+              separately on your account <a href='https://accounts.firefox.com/'>settings page</a>.</p>
 
             <h2 id='you-are-responsible'>You Are Responsible For the Content You Provide</h2>
 
@@ -174,7 +174,7 @@ class TermsOfService extends React.PureComponent {
               acceptance of such changes. We will post an effective date at the
               top of this page to make it clear when we made our most recent
               update. If the update is significant, we will contact you at the
-              primary email address for your account to let you know
+              primary email address for your Mozilla account to let you know
               about the changes.</p>
 
             <p>Termination. These Terms apply until they are modified, or

--- a/app/javascript/mastodon/features/terms_of_service/index.jsx
+++ b/app/javascript/mastodon/features/terms_of_service/index.jsx
@@ -30,7 +30,7 @@ class TermsOfService extends React.PureComponent {
         <div className='scrollable privacy-policy'>
           <div className='column-title'>
             <h3>Terms of Service</h3>
-            <p>Version 0.2, effective October 4, 2023</p>
+            <p>Version 0.2, effective November 1, 2023</p>
           </div>
 
           <div className='privacy-policy__body prose'>


### PR DESCRIPTION
# DO NOT MERGE

Prior to November 1 - new copy contains "Mozilla account"

## Goal

Update FxA-related copy to conform to the new guidelines anywhere we have legal docs hardcoded in the repository.

Note this turned out to be only the "Terms of Service" page and nothing else. 

## References

https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-711