### PR TITLE
feat(trust & safety): [SOCIALPLAT-766] Immediately remove public copy of media when status is deleted

### DIFF
--- a/app/controllers/api/v1/admin/statuses_controller.rb
+++ b/app/controllers/api/v1/admin/statuses_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::Admin::StatusesController < Api::BaseController
       if @status.with_media?
         # Immediately remove public copy of media instead of waiting for
         # the vacuum_orphaned_records job to take care of it later on
-        destroy_associated_media
+        Admin::MediaAttachmentDeletionWorker.perform_inline(@status.media_attachments)
       end
     end
 
@@ -54,12 +54,5 @@ class Api::V1::Admin::StatusesController < Api::BaseController
 
   def set_status
     @status = Status.find(params[:id])
-  end
-
-  def destroy_associated_media!
-    @status.ordered_media_attachments.each do |media|
-      media.destroy
-      log_action :destroy, media
-    end
   end
 end

--- a/app/models/admin/status_batch_action.rb
+++ b/app/models/admin/status_batch_action.rb
@@ -47,6 +47,12 @@ class Admin::StatusBatchAction
       statuses.each do |status|
         status.discard_with_reblogs
         log_action(:destroy, status)
+
+        next unless status.with_media?
+
+        # Immediately remove public copy of media instead of waiting for
+        # the vacuum_orphaned_records job to take care of it later on
+        Admin::MediaAttachmentDeletionWorker.perform_inline(status.media_attachments)
       end
 
       if with_report?

--- a/app/workers/admin/media_attachment_deletion_worker.rb
+++ b/app/workers/admin/media_attachment_deletion_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Admin::MediaAttachmentDeletionWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
+
+  def perform(media_attachments)
+    # remove both attachments and associations between statuses and media
+    AttachmentBatch.new(MediaAttachment, media_attachments).clear
+  end
+end

--- a/app/workers/admin/media_attachment_deletion_worker.rb
+++ b/app/workers/admin/media_attachment_deletion_worker.rb
@@ -6,7 +6,6 @@ class Admin::MediaAttachmentDeletionWorker
   sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(media_attachments)
-    # remove both attachments and associations between statuses and media
     AttachmentBatch.new(MediaAttachment, media_attachments).clear
   end
 end

--- a/spec/controllers/api/v1/admin/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/statuses_controller_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Api::V1::Admin::StatusesController do
 
   describe 'DELETE #destroy' do
     let(:scopes) { 'admin:write:statuses' }
-    let(:status) { Fabricate(:status) }
+    let(:media)  { Fabricate(:media_attachment) }
+    let(:status) { Fabricate(:status, media_attachments: [media]) }
 
     before do
       post :destroy, params: { id: status.id }
@@ -47,6 +48,10 @@ RSpec.describe Api::V1::Admin::StatusesController do
 
     it 'removes the status' do
       expect(Status.find_by(id: status.id)).to be_nil
+    end
+
+    it 'removes associated media' do
+      expect(MediaAttachment.find_by(id: media.id)).to be_nil
     end
   end
 

--- a/spec/workers/admin/media_attachment_deletion_worker_spec.rb
+++ b/spec/workers/admin/media_attachment_deletion_worker_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::MediaAttachmentDeletionWorker do
+  let(:worker) { described_class.new }
+  let(:local_status) { Fabricate(:status) }
+  let(:remote_status) { Fabricate(:status, account: Fabricate(:account, domain: 'example.com')) }
+
+  describe 'perform' do
+    let!(:remote_media) { Fabricate(:media_attachment, remote_url: 'https://example.com/foo.png', status: remote_status) }
+    let!(:local_media) { Fabricate(:media_attachment, status: local_status) }
+
+    it 'deletes remote media attachments' do
+      subject.perform([remote_media])
+      expect(remote_media.reload.file).to be_blank
+    end
+
+    it 'deletes local media attachments' do
+      subject.perform([local_media])
+      expect(local_media.reload.file).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
Immediately remove public copy of media when status is deleted.

- Updated `destroy` method in StatusesController
- Updated unit tests

JIRA reference: https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-766