### PR TITLE
build(glean): adding the probe scrapper gha as required by Glean

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -1,0 +1,5 @@
+name: Glean probe-scraper
+on: [push, pull_request]
+jobs:
+  glean-probe-scraper:
+    uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
Per https://mozilla.github.io/glean/book/user/adding-glean-to-your-project/enable-data-ingestion.html#add-your-product-to-probe-scraper we need to add this github action to make sure Glean dictionary is proper populated.

this was also done for elk: https://github.com/MozillaSocial/elk/blob/main/.github/workflows/glean-probe-scraper.yml